### PR TITLE
Feature/python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "hera",
     "cwl-utils",
     "click",
-    "cwl-utils==0.14",
+    "cwl-utils>=0.14",
     "attrs",
     "loguru"
 ]
@@ -29,7 +29,7 @@ dependencies = [
     "hera",
     "cwl-utils",
     "click",
-    "cwl-utils==0.14",
+    "cwl-utils>=0.14",
     "attrs",
     "loguru"
 ]
@@ -41,7 +41,7 @@ dependencies = [
     "hera",
     "cwl-utils",
     "click",
-    "cwl-utils==0.14",
+    "cwl-utils>=0.14",
     "attrs",
     "loguru"
 ]

--- a/tests/tests_water_bodies_cloud_native.py
+++ b/tests/tests_water_bodies_cloud_native.py
@@ -42,7 +42,7 @@ class TestWaterBodiesCloudNativeService(unittest.TestCase):
         conf["lenv"] = {"message": "", "Identifier": "water-bodies", "usid": "def-1234"}
         conf["tmpPath"] = "/tmp"
         conf["main"] = {"tmpUrl": "http://localhost/logs/"}
-        conf["auth_env"] = {"user": "ns1"}
+        conf["argo"] = {"namespace": "ns1"}
         cls.conf = conf
 
         inputs = {

--- a/tests/tests_water_body.py
+++ b/tests/tests_water_body.py
@@ -42,7 +42,7 @@ class TestWaterBodiesService(unittest.TestCase):
         conf["lenv"] = {"message": "", "Identifier": "water-bodies", "usid": "abc-1234"}
         conf["tmpPath"] = "/tmp"
         conf["main"] = {"tmpUrl": "http://localhost/logs/"}
-        conf["auth_env"] = {"user": "ns1"}
+        conf["argo"] = {"namespace": "ns1"}
         cls.conf = conf
 
         inputs = {

--- a/zoo_argowf_runner/argo_api.py
+++ b/zoo_argowf_runner/argo_api.py
@@ -117,6 +117,8 @@ class Execution:
         def progress_to_percentage(progress: str) -> int:
             """Convert progress string (e.g., '2/10') to percentage."""
             completed, total = map(int, progress.split("/"))
+            if total == 0:
+                return 0
             return int((completed / total) * 100)
 
         while True:

--- a/zoo_argowf_runner/runner.py
+++ b/zoo_argowf_runner/runner.py
@@ -154,7 +154,7 @@ class ZooArgoWorkflowsRunner:
         self.update_status(progress=15, message="upload required files")
 
         self.execution = Execution(
-            namespace=self.zoo_conf.conf["auth_env"]["user"],
+            namespace=self.zoo_conf.conf["argo"]["namespace"],
             workflow=self.cwl,
             entrypoint=self.get_workflow_id(),
             workflow_name=self.get_workflow_uid(),

--- a/zoo_argowf_runner/zoo_helpers.py
+++ b/zoo_argowf_runner/zoo_helpers.py
@@ -4,7 +4,7 @@ import attr
 import inspect
 import cwl_utils
 from cwl_utils.parser import load_document_by_yaml
-
+import cwl_utils.__meta__ as cwl_meta
 
 # useful class for hints in CWL
 @attr.s
@@ -28,7 +28,10 @@ class ResourceRequirement:
 class CWLWorkflow:
     def __init__(self, cwl, workflow_id):
         self.raw_cwl = cwl
-        self.cwl = load_document_by_yaml(cwl, "io://")
+        if cwl_meta.__version__ < "0.16":
+            self.cwl = load_document_by_yaml(cwl, "io://")
+        else:
+            self.cwl = load_document_by_yaml(cwl, "io://", id_=workflow_id, load_all=True)
         self.workflow_id = workflow_id
 
     def get_version(self):
@@ -56,8 +59,9 @@ class CWLWorkflow:
     def get_workflow_inputs(self, mandatory=False):
         inputs = []
         for inp in self.get_workflow().inputs:
+            my_current_type = inp.type if cwl_meta.__version__ < "0.16" else inp.type_
             if mandatory:
-                if inp.default is not None or inp.type == ["null", "string"]:
+                if inp.default is not None or my_current_type == ["null", "string"]:
                     continue
                 else:
                     inputs.append(inp.id.split("/")[-1])


### PR DESCRIPTION
Upgrade from `cwl-utils` version 0.14 to 0.39.

Use a dedicated `argo` section to set the namespace to use.

When a workflow is not directly executed but is in a queue, `total` is set to 0, leading to an issue with the division.